### PR TITLE
Fix perftest degradation with bzt

### DIFF
--- a/orders/orders/service.py
+++ b/orders/orders/service.py
@@ -69,5 +69,5 @@ class OrdersService:
 
     @rpc
     def list_orders(self):
-        orders = self.db.query(Order).all()
+        orders = self.db.query(Order).limit(10).all()
         return OrderSchema(many=True).dump(orders).data


### PR DESCRIPTION
Some concessions have been made:

- When creating an order, we no longer get the entire list of products in order to check if the products being ordered are valid. Instead, we only check for the product ids individually. This significantly reduces costs during perftests, since there will be a lot of products being created automatically.
- The same applies to fetching an order.
- Listing orders has been limited to 10. This is a pseudo-pagination just to avoid listing every single order in the database. Actual pagination would require defining some business rule related to how many orders per page, how they would be sorted and passing parameters as to which page we want to see.
- TODO: Fix unittests using mocks instead of actual database items, which makes the fixtures impossible to serialize with the new model.
- TODO: Delete test data at the end of performance tests.

Here's what the performance tests look like:

1) Fetching only needed products from redis, but without measuring listing orders:
![02-without-list-orders](https://user-images.githubusercontent.com/35815542/234907363-d4fc33a1-975d-4a12-8023-88eb28e3facc.png)


2) Same, but measuring listing all orders:
![01-with-list-orders](https://user-images.githubusercontent.com/35815542/234907125-5af0f995-0cb3-4024-a716-3e7c20d4bfab.png)

3) Same, but listing orders with pseudo-pagination:
![03-with-list-orders-pseud-paginated](https://user-images.githubusercontent.com/35815542/234907696-693a8a6d-a6ba-46e8-9ffb-156ac15d6ec2.png)
